### PR TITLE
Set XZ compression by default

### DIFF
--- a/conf/initramfs.conf
+++ b/conf/initramfs.conf
@@ -33,7 +33,7 @@ BUSYBOX=auto
 # COMPRESS: [ gzip | bzip2 | lz4 | lzma | lzop | xz | zstd ]
 #
 
-COMPRESS=zstd
+COMPRESS=xz
 
 #
 # DEVICE: ...

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+initramfs-tools (0.140ubuntu13.4pop1) jammy; urgency=medium
+
+  * Change default compression to xz
+
+ -- Michael Aaron Murphy <michael@mmurphy.dev>  Mon, 18 Mar 2024 19:20:27 +0100
+
 initramfs-tools (0.140ubuntu13.4) jammy; urgency=medium
 
   * hook-functions: add stusb160x kernel module for Tegra IGX (LP: #2027636)


### PR DESCRIPTION
We may also look into what's necessary to enable compressing firmware with xz or zstd by default.